### PR TITLE
Ensure Ruby >= 2.0 for autoprefixer-rails-6.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby ">= 1.9.3"
+ruby '>= 2.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+ruby ">= 1.9.3"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.4'


### PR DESCRIPTION
- Ruby >= 1.9.3 for Rails 4
- autoprefixer-rails-6.1.2 requires ruby version >= 2.0