### PR TITLE
Fix Heroku deploy Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.0'
+ruby '>= 2.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,3 +298,9 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   validates_formatting_of
+
+RUBY VERSION
+   ruby 2.5.1p57
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
Currently we got this error via the Heroku deploy button:

<img width="664" alt="screen shot 2018-08-14 at 09 13 34" src="https://user-images.githubusercontent.com/570901/44076964-634786f2-9fa2-11e8-9913-e2cb0931ef70.png">
